### PR TITLE
fix: disable csv header parsing

### DIFF
--- a/src/utils/papaparse.ts
+++ b/src/utils/papaparse.ts
@@ -3,7 +3,7 @@ import { parse, ParseResult } from 'papaparse';
 export async function parseCsv<T = Record<string, unknown>>(file: File): Promise<ParseResult<T>> {
     return new Promise<ParseResult<T>>((resolve, reject) => {
         parse<T>(file, {
-            header: true,
+            header: false,
             skipEmptyLines: true,
             transform: (value: string): string => {
                 return value.trim();


### PR DESCRIPTION
默认情况下，CSV解析时header选项为true，这会导致解析结果包含表头。根据需求，现将其设置为false，以避免表头被包含在解析结果中。